### PR TITLE
Cleanup Markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#CSHR API
+# CSHR API
 
 ## Prerequisites
 
@@ -18,15 +18,15 @@ The api supports Spring Profiles. We have two profiles available 'dev' and 'prod
 
 To start the docker container from the command line, indicating the Spring Profile to use:
 
-###dev Spring profile
+### Setting the spring profile
 
-'SPRING_PROFILES_ACTIVE=dev docker-compose up api'
+`SPRING_PROFILES_ACTIVE=dev docker-compose up api`
 
 *Note: The 'dev' profile will give access to full Swagger capability such as the ability to use Swagger UI to try out the api.  This must not be allowed in any environment other than a development one.*
 
-###prod Spring Profile
+For production, pass in "prod".
 
-'SPRING_PROFILES_ACTIVE=prod docker-compose up api'
+`SPRING_PROFILES_ACTIVE=prod docker-compose up api`
 
 ## Stopping API
 


### PR DESCRIPTION
__What?__

Whilst having a ganders through the repos, some of the Markdown was not rendering correctly. The Markdown was changed and updated slightly to ensure correct rendering on GitHub.

__How to test?__

View the readme file on GitHub - you should see no hash signs (#) and all code / terminal commands should be formatted as preformated text.

__Who can test?__

Anyone
