### PR TITLE
missed environment variable for bintray url.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ jobs:
   ship:
     environment:
       - COMPOSE_FILE: "docker-compose.yml"
+      - BINTRAY_URL: "cshr-docker-rpg.bintray.io"
+
     machine: true
     steps:
       - checkout


### PR DESCRIPTION
forgot to add bintray URL - as environment variable so its trying to login to docker hub.
I cant test this stuff anywhere without pushing to circleci!