### PR TITLE
changed reference to maven image from docker hub to cshr maven image

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,7 +14,7 @@ services:
       - cshr-net
 
   test:
-    image: maven:3.5-jdk-8
+    image: cshrrpg.azurecr.io/maven-3-base 
     working_dir: "/usr/src/app"
     volumes:
       - "~/.m2:/root/.m2"


### PR DESCRIPTION
Updated reference to cshr maven image, this is to satisfy something flagged on Pen test report.