### PR TITLE
CSHRCP-1049 - Added ability to notify invalid location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </parent>
 
     <properties>
-        <cshr.common.version>1.0.0</cshr.common.version>
+        <cshr.common.version>1.1.0</cshr.common.version>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/vcm/src/docs/swagger/swagger.yaml
+++ b/vcm/src/docs/swagger/swagger.yaml
@@ -531,11 +531,9 @@ definitions:
       authenticatedEmail:
         type: string
         description: The email which was verified to give access to non-public jobs
-      cshrServiceStatuses:
-        type: array
-        description: A list of statuses indicating the system status
-        items:
-          $ref: '#/definitions/CSHRServiceStatus'
+      cshrServiceStatus:
+        description: Business status code associated with the request
+        $ref: '#/definitions/CSHRServiceStatus'
       vacancies:
         description: 'The search results '
         $ref: '#/definitions/Page«Vacancy»'
@@ -593,6 +591,9 @@ definitions:
         type: integer
         format: int64
       internalOpeningDate:
+        type: string
+        example: 'yyyy-MM-dd''T''HH:mm:ss.SSSZ'
+      lastModified:
         type: string
         example: 'yyyy-MM-dd''T''HH:mm:ss.SSSZ'
       lengthOfEmployment:
@@ -748,7 +749,7 @@ definitions:
   VacancyMetadata:
     type: object
     properties:
-      identifer:
+      identifier:
         type: integer
         format: int64
       lastModified:

--- a/vcm/src/main/java/uk/gov/cshr/vcm/model/SearchResponse.java
+++ b/vcm/src/main/java/uk/gov/cshr/vcm/model/SearchResponse.java
@@ -25,9 +25,8 @@ public class SearchResponse {
     @Builder.Default
     private List<VacancyError> vacancyErrors = new ArrayList<>();
 
-    @ApiModelProperty(notes = "A list of statuses indicating the system status")
-    @Builder.Default
-    private List<CSHRServiceStatus> cshrServiceStatuses = new ArrayList<>();
+    @ApiModelProperty(notes = "Business status code associated with the request")
+    private CSHRServiceStatus cshrServiceStatus;
 
     @ApiModelProperty(notes = "The email which was verified to give access to non-public jobs")
     private String authenticatedEmail;

--- a/vcm/src/main/java/uk/gov/cshr/vcm/service/SearchService.java
+++ b/vcm/src/main/java/uk/gov/cshr/vcm/service/SearchService.java
@@ -8,6 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import uk.gov.cshr.status.CSHRServiceStatus;
+import uk.gov.cshr.status.StatusCode;
 import uk.gov.cshr.vcm.controller.exception.LocationServiceException;
 import uk.gov.cshr.vcm.model.Coordinates;
 import uk.gov.cshr.vcm.model.SearchParameters;
@@ -44,6 +46,10 @@ public class SearchService {
             if (coordinatesExist(coordinates)) {
                 searchParameters.setCoordinates(coordinates);
             } else {
+                searchResponse.setCshrServiceStatus(CSHRServiceStatus.builder()
+                        .code(StatusCode.NO_RESULTS_FOR_LOCATION.getCode())
+                        .summary("The location service was unable to match the location supplied.")
+                        .build());
                 debug("No Coordinates for %s with radius of %d exist",
                         vacancySearchParameters.getLocation().getPlace(),
                         vacancySearchParameters.getLocation().getRadius());

--- a/vcm/src/test/java/uk/gov/cshr/vcm/controller/SearchResponsePage.java
+++ b/vcm/src/test/java/uk/gov/cshr/vcm/controller/SearchResponsePage.java
@@ -21,9 +21,9 @@ public class SearchResponsePage extends SearchResponse {
     public SearchResponsePage(
             @JsonProperty("vacancies") VacancyPage vacancyPage,
             @JsonProperty("vacanyErrors") List<VacancyError> vacanyErrors,
-            @JsonProperty("cshrServiceStatuses") List<CSHRServiceStatus> cshrServiceStatuses,
+            @JsonProperty("cshrServiceStatus") CSHRServiceStatus cshrServiceStatus,
             @JsonProperty("authenticatedEmail") String authenticatedEmail) {
 
-        super(vacancyPage, vacanyErrors, cshrServiceStatuses, authenticatedEmail);
+        super(vacancyPage, vacanyErrors, cshrServiceStatus, authenticatedEmail);
     }
 }


### PR DESCRIPTION
The response will contain the following in the response (near the bottom):

"cshrServiceStatus": {
        "code": "CSHR_400",
        "summary": "The location service was unable to match the location supplied.",
        "detail": null
    },

So you just need to check for the presence of code CHSR_400 to indicate no data was found for the location given.  If this is the case the search will continue as if no location had been supplied in the first place.